### PR TITLE
Pin Versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "devDependencies": {
-    "@sveltejs/adapter-auto": "next",
-    "@sveltejs/kit": "next",
-    "svelte": "3.55.0",
-    "svelte-check": "2.10.2",
-    "typescript": "4.9.4",
-    "vite": "4.0.1"
+    "@sveltejs/adapter-auto": "^2.0.0",
+    "@sveltejs/kit": "^1.15.7",
+    "svelte": "^3.58.0",
+    "svelte-check": "^3.2.0",
+    "typescript": "^5.0.4",
+    "vite": "^4.3.1"
   },
   "dependencies": {
     "@auth/core": "latest",


### PR DESCRIPTION
It's probably a good idea to pin minor versions instead of using 'next' otherwise you'll have to check this repo for every breaking change in SvelteKit.