### PR TITLE
Update +layout.svelte

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import Header from "$components/header.svelte"
   import Footer from "$components/footer.svelte"
+  let { children } = $props();
 </script>
 
 <div class="container">
   <Header />
-  <slot />
+  {@render children()}
   <Footer />
 </div>
 


### PR DESCRIPTION
Changing old syntax for svelte 5 syntax. Where  instead use <slot/> it's recommended to use children.